### PR TITLE
fixed template argument of SimulaterTraitsBase in test case of float

### DIFF
--- a/test/mjolnir/test_excluded_volume_potential.cpp
+++ b/test/mjolnir/test_excluded_volume_potential.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(EXV_double)
 
 BOOST_AUTO_TEST_CASE(EXV_float)
 {
-    typedef mjolnir::SimulatorTraitsBase<double, mjolnir::UnlimitedBoundary> traits;
+    typedef mjolnir::SimulatorTraitsBase<float, mjolnir::UnlimitedBoundary> traits;
     constexpr static std::size_t       N    = 1000;
     constexpr static traits::real_type h    = 1e-3;
 


### PR DESCRIPTION
In test_excluded_volume_potential.cpp, template argument of SimulatorTrairsBase in EXV_float should be float. So this is the revision.