### PR TITLE
Simplify implementation of random number generator

### DIFF
--- a/mjolnir/core/RandomNumberGenerator.hpp
+++ b/mjolnir/core/RandomNumberGenerator.hpp
@@ -20,12 +20,20 @@ class RandomNumberGenerator
     {}
     ~RandomNumberGenerator() = default;
 
-    real_type uniform_real(const real_type min, const real_type max);
-    real_type gaussian(const real_type mean, const real_type sigma);
+    real_type uniform_real(const real_type min, const real_type max)
+    {
+        return this->uni_(this->rng_) * (max - min) + min;
+    }
+    real_type gaussian(const real_type mean, const real_type stddev)
+    {
+        return this->nrm_(this->rng_) * stddev + mean;
+    }
 
   private:
     const std::uint32_t seed_;
-    std::mt19937 rng_;
+    std::mt19937        rng_;
+    std::uniform_real_distribution<real_type> uni_;
+    std::normal_distribution<real_type>       nrm_;
 };
 
 template<typename traitsT>

--- a/mjolnir/core/RandomNumberGenerator.hpp
+++ b/mjolnir/core/RandomNumberGenerator.hpp
@@ -36,21 +36,5 @@ class RandomNumberGenerator
     std::normal_distribution<real_type>       nrm_;
 };
 
-template<typename traitsT>
-inline typename RandomNumberGenerator<traitsT>::real_type
-RandomNumberGenerator<traitsT>::uniform_real(
-    const real_type min, const real_type max)
-{
-    return (std::uniform_real_distribution<real_type>(min, max))(rng_);
-}
-
-template<typename traitsT>
-inline typename RandomNumberGenerator<traitsT>::real_type
-RandomNumberGenerator<traitsT>::gaussian(
-    const real_type mean, const real_type sigma)
-{
-    return (std::normal_distribution<real_type>(mean, sigma))(rng_);
-}
-
 } // mjolnir
 #endif /*MJOLNIR_CORE_RANDOM_NUMBER_GENERATOR*/

--- a/mjolnir/core/RandomNumberGenerator.hpp
+++ b/mjolnir/core/RandomNumberGenerator.hpp
@@ -10,9 +10,9 @@ template<typename traitsT>
 class RandomNumberGenerator
 {
   public:
-    typedef traitsT traits_type;
-    typedef typename traits_type::real_type real_type;
-    typedef typename traits_type::coordinate_type coordinate_type;
+    using traits_type     = traitsT;
+    using real_type       = typename traits_type::real_type;
+    using coordinate_type = typename traits_type::coordinate_type;
 
   public:
     RandomNumberGenerator(const std::uint32_t seed)

--- a/mjolnir/core/RandomNumberGenerator.hpp
+++ b/mjolnir/core/RandomNumberGenerator.hpp
@@ -23,14 +23,6 @@ class RandomNumberGenerator
     real_type uniform_real(const real_type min, const real_type max);
     real_type gaussian(const real_type mean, const real_type sigma);
 
-    coordinate_type
-    maxwell_boltzmann(const real_type mass, const real_type temperature,
-                      const real_type kB);
-
-    coordinate_type
-    underdamped_langevin(const real_type mass, const real_type gamma,
-        const real_type dt, const real_type temperature, const real_type kB);
-
   private:
     const std::uint32_t seed_;
     std::mt19937 rng_;
@@ -50,25 +42,6 @@ RandomNumberGenerator<traitsT>::gaussian(
     const real_type mean, const real_type sigma)
 {
     return (std::normal_distribution<real_type>(mean, sigma))(rng_);
-}
-
-template<typename traitsT>
-inline typename RandomNumberGenerator<traitsT>::coordinate_type
-RandomNumberGenerator<traitsT>::maxwell_boltzmann(
-    const real_type m, const real_type T, const real_type kB)
-{
-    std::normal_distribution<real_type> distro(0., std::sqrt(kB * T / m));
-    return coordinate_type(distro(rng_), distro(rng_), distro(rng_));
-}
-
-template<typename traitsT>
-inline typename RandomNumberGenerator<traitsT>::coordinate_type
-RandomNumberGenerator<traitsT>::underdamped_langevin(const real_type m,
-        const real_type g, const real_type dt, const real_type T, const real_type kB)
-{
-    std::normal_distribution<real_type>
-        distro(0., std::sqrt(2 * kB * T * g / (m * dt)));
-    return coordinate_type(distro(rng_), distro(rng_), distro(rng_));
 }
 
 } // mjolnir


### PR DESCRIPTION
this PR includes the following changes.
- remove unused functions
- keep normal_distribution and uniform_real_distribution

it is not good to have functions that are specific to some features in the RNG, because RNG is just a generator, not an integrator or simulator.
Also, discarding distribution classes maybe inefficient. They may keep unused random bits. For example, Marsaglia polar method generates two random variables by one invocation, and the unused one is kept inside. discarding this class also discards these values and generating random numbers would be inefficient.
