### PR TITLE
use Boost.toml

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "extlib/toml"]
 	path = extlib/toml
-	url = https://github.com/ToruNiina/toml11.git
+	url = https://github.com/ToruNiina/Boost.toml.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,11 @@ if(USE_APPROX)
     add_definitions(-DMJOLNIR_WITH_APPROX)
 endif()
 
-if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extlib/toml/toml.hpp")
+if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extlib/toml/toml/toml.hpp")
     execute_process(COMMAND git submodule update --init --recursive
                     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endif()
+include_directories(${PROJECT_SOURCE_DIR}/extlib/toml)
 
 if(BOOST_ROOT)
     # if BOOST_ROOT is manually defined, use the library.

--- a/mjolnir/input/read_forcefield.hpp
+++ b/mjolnir/input/read_forcefield.hpp
@@ -1,6 +1,6 @@
 #ifndef MJOLNIR_READ_FORCEFIELD
 #define MJOLNIR_READ_FORCEFIELD
-#include <extlib/toml/toml.hpp>
+#include <extlib/toml/toml/toml.hpp>
 #include <mjolnir/core/ForceField.hpp>
 #include <mjolnir/util/get_toml_value.hpp>
 #include <mjolnir/util/logger.hpp>
@@ -11,7 +11,7 @@ namespace mjolnir
 
 template<typename traitsT>
 LocalForceField<traitsT>
-read_local_forcefield(std::vector<toml::Table> interactions,
+read_local_forcefield(std::vector<toml::table> interactions,
                       const std::string& input_path)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
@@ -56,7 +56,7 @@ read_local_forcefield(std::vector<toml::Table> interactions,
                     "[local] should be provided as a root object of file ",
                     file_name, ". but [local] table found");
 
-                if(forcefield_file.at("local").type() != toml::value_t::Table)
+                if(!forcefield_file.at("local").is(toml::value::table_tag))
                 {
                     MJOLNIR_LOG_ERROR("type of `local` is different from toml::"
                                       "Table in file (", file_name, ").");
@@ -65,7 +65,7 @@ read_local_forcefield(std::vector<toml::Table> interactions,
                     std::exit(1);
                 }
                 lff.emplace(read_local_interaction<traitsT>(
-                    get_toml_value<toml::Table>(
+                    get_toml_value<toml::table>(
                         forcefield_file, "local", file_name)));
             }
             else
@@ -83,7 +83,7 @@ read_local_forcefield(std::vector<toml::Table> interactions,
 
 template<typename traitsT>
 GlobalForceField<traitsT>
-read_global_forcefield(std::vector<toml::Table> interactions,
+read_global_forcefield(std::vector<toml::table> interactions,
                        const std::string& input_path)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
@@ -128,16 +128,16 @@ read_global_forcefield(std::vector<toml::Table> interactions,
                     "[global] should be provided as a root object of file ",
                     file_name, ". but [global] key found");
 
-                if(forcefield_file.at("global").type() != toml::value_t::Table)
+                if(!forcefield_file.at("global").is(toml::value::table_tag))
                 {
                     MJOLNIR_LOG_ERROR("type of `global` is different from "
-                                      "toml::Table in file (", file_name, ").");
+                                      "toml::table in file (", file_name, ").");
                     MJOLNIR_LOG_ERROR("note: [[...]] means Array-of-Tables. "
                                       "please take care.");
                     std::exit(1);
                 }
                 gff.emplace(read_global_interaction<traitsT>(
-                    get_toml_value<toml::Table>(
+                    get_toml_value<toml::table>(
                         forcefield_file, "global", file_name)));
             }
             else
@@ -155,7 +155,7 @@ read_global_forcefield(std::vector<toml::Table> interactions,
 
 template<typename traitsT>
 ExternalForceField<traitsT>
-read_external_forcefield(std::vector<toml::Table> interactions,
+read_external_forcefield(std::vector<toml::table> interactions,
                          const std::string& input_path)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
@@ -200,17 +200,17 @@ read_external_forcefield(std::vector<toml::Table> interactions,
                     "[external] should be provided as a root object of file ",
                     file_name, ". but [external] key found");
 
-                if(forcefield_file.at("external").type() != toml::value_t::Table)
+                if(!forcefield_file.at("external").is(toml::value::table_tag))
                 {
                     MJOLNIR_LOG_ERROR("type of `external` is different from "
-                                      "toml::Table in file (", file_name, ").");
+                                      "toml::table in file (", file_name, ").");
                     MJOLNIR_LOG_ERROR("note: [[...]] means Array-of-Tables. "
                                       "please take care.");
                     std::exit(1);
                 }
 
                 eff.emplace(read_external_interaction<traitsT>(
-                    get_toml_value<toml::Table>(
+                    get_toml_value<toml::table>(
                         forcefield_file, "external", file_name)));
             }
             else
@@ -228,28 +228,28 @@ read_external_forcefield(std::vector<toml::Table> interactions,
 
 template<typename traitsT>
 ForceField<traitsT>
-read_forcefield_from_table(const toml::Table& ff, const std::string& input_path)
+read_forcefield_from_table(const toml::table& ff, const std::string& input_path)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_forcefield_from_table(), 0);
 
-    std::vector<toml::Table> fflocal, ffglobal, ffexternal;
+    std::vector<toml::table> fflocal, ffglobal, ffexternal;
     if(ff.count("local") == 1)
     {
         MJOLNIR_LOG_INFO("LocalForceField found");
-        fflocal = get_toml_value<std::vector<toml::Table>>(
+        fflocal = get_toml_value<std::vector<toml::table>>(
                 ff, "local", "[[forcefields]]");
     }
     if(ff.count("global") == 1)
     {
         MJOLNIR_LOG_INFO("GlobalForceField found");
-        ffglobal = get_toml_value<std::vector<toml::Table>>(
+        ffglobal = get_toml_value<std::vector<toml::table>>(
                 ff, "global", "[[forcefields]]");
     }
     if(ff.count("external") == 1)
     {
         MJOLNIR_LOG_INFO("ExternalForceField found");
-        ffexternal = get_toml_value<std::vector<toml::Table>>(
+        ffexternal = get_toml_value<std::vector<toml::table>>(
                 ff, "external", "[[forcefields]]");
     }
 
@@ -270,13 +270,13 @@ read_forcefield_from_table(const toml::Table& ff, const std::string& input_path)
 
 template<typename traitsT>
 ForceField<traitsT>
-read_forcefield(const toml::Table& data, std::size_t N)
+read_forcefield(const toml::table& data, std::size_t N)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_forcefield(), 0);
     MJOLNIR_LOG_NOTICE("reading ", N, "-th [[forcefield]].");
 
-    const auto& files = get_toml_value<toml::Table>(data, "files", "<root>");
+    const auto& files = get_toml_value<toml::table>(data, "files", "<root>");
     std::string input_path_("./");
     if(files.count("input_path") == 1)
     {
@@ -285,7 +285,7 @@ read_forcefield(const toml::Table& data, std::size_t N)
     const auto input_path(input_path_); // add constness
     MJOLNIR_LOG_INFO("input path is -> ", input_path);
 
-    const auto& ffs = get_toml_value<toml::Array>(data, "forcefields", "<root>");
+    const auto& ffs = get_toml_value<toml::array>(data, "forcefields", "<root>");
     if(ffs.size() <= N)
     {
         throw std::out_of_range("no enough forcefields: " + std::to_string(N));
@@ -293,7 +293,7 @@ read_forcefield(const toml::Table& data, std::size_t N)
     MJOLNIR_LOG_INFO(ffs.size(), " forcefields are provided");
     MJOLNIR_LOG_INFO("using ", N, "-th forcefield");
 
-    const auto& ff = ffs.at(N).cast<toml::value_t::Table>();
+    const auto& ff = toml::get<toml::table>(ffs.at(N));
     if(ff.count("file_name") == 1)
     {
         MJOLNIR_SCOPE(ff.count("file_name") == 1, 1);
@@ -321,16 +321,16 @@ read_forcefield(const toml::Table& data, std::size_t N)
             MJOLNIR_LOG_WARN("in ", file_name, ", [forcefields] key found."
                              "trying to read it as a forcefield setup.");
 
-            if(forcefield_file.at("forcefields").type() != toml::value_t::Table)
+            if(!forcefield_file.at("forcefields").is(toml::value::table_tag))
             {
                 MJOLNIR_LOG_ERROR("type of `forcefields` is different from "
-                                  "toml::Table in file (", file_name, ").");
+                                  "toml::table in file (", file_name, ").");
                 MJOLNIR_LOG_ERROR("note: [[...]] means Array-of-Tables. "
                                   "please take care.");
                 std::exit(1);
             }
-            return read_forcefield_from_table<traitsT>(forcefield_file.at(
-                    "forcefields").template cast<toml::value_t::Table>(),
+            return read_forcefield_from_table<traitsT>(
+                    toml::get<toml::table>(forcefield_file.at("forcefields")),
                     input_path);
         }
         return read_forcefield_from_table<traitsT>(forcefield_file, input_path);

--- a/mjolnir/input/read_input_file.hpp
+++ b/mjolnir/input/read_input_file.hpp
@@ -1,6 +1,6 @@
 #ifndef MJOLNIR_READ_INPUT_FILE
 #define MJOLNIR_READ_INPUT_FILE
-#include <extlib/toml/toml.hpp>
+#include <extlib/toml/toml/toml.hpp>
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/constants.hpp>
 #include <mjolnir/core/SimulatorBase.hpp>
@@ -15,10 +15,10 @@ namespace mjolnir
 
 template<typename realT>
 std::unique_ptr<SimulatorBase>
-read_boundary(const toml::Table& data)
+read_boundary(const toml::table& data)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
-    MJOLNIR_SCOPE(read_boundary(const toml::Table& data), 0);
+    MJOLNIR_SCOPE(read_boundary(const toml::table& data), 0);
 
     // [simulator] can be provided in a different file. in that case, the table
     // has `file_name` field. In that case, input_path is also needed to
@@ -27,14 +27,14 @@ read_boundary(const toml::Table& data)
     std::string boundary;
 
     const auto& simulator =
-        get_toml_value<toml::Table>(data, "simulator", "<root>");
+        get_toml_value<toml::table>(data, "simulator", "<root>");
 
     if(simulator.count("file_name") == 1)
     {
         const auto filename = toml::get<std::string>(simulator.at("file_name"));
         std::string input_path; //default: empty
 
-        const auto& files = get_toml_value<toml::Table>(data, "files", "<root>");
+        const auto& files = get_toml_value<toml::table>(data, "files", "<root>");
         if(files.count("input_path") == 1)
         {
             input_path = toml::get<std::string>(files.at("input_path"));
@@ -69,10 +69,10 @@ read_boundary(const toml::Table& data)
 }
 
 inline std::unique_ptr<SimulatorBase>
-read_precision(const toml::Table& data)
+read_precision(const toml::table& data)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
-    MJOLNIR_SCOPE(read_precision(const toml::Table& data), 0);
+    MJOLNIR_SCOPE(read_precision(const toml::table& data), 0);
 
     // [simulator] can be provided in a different file. in that case, the table
     // has `file_name` field. In that case, input_path is also needed to
@@ -81,14 +81,14 @@ read_precision(const toml::Table& data)
     std::string prec;
 
     const auto& simulator =
-        get_toml_value<toml::Table>(data, "simulator", "<root>");
+        get_toml_value<toml::table>(data, "simulator", "<root>");
 
     if(simulator.count("file_name") == 1)
     {
         const auto filename = toml::get<std::string>(simulator.at("file_name"));
         std::string input_path; //default: empty
 
-        const auto& files = get_toml_value<toml::Table>(data, "files", "<root>");
+        const auto& files = get_toml_value<toml::table>(data, "files", "<root>");
         if(files.count("input_path") == 1)
         {
             input_path = toml::get<std::string>(files.at("input_path"));
@@ -128,7 +128,7 @@ read_input_file(const std::string& filename)
     std::cerr << " successfully parsed." << std::endl;
 
     // initializing logger by using output_path and output_prefix ...
-    const auto& files = get_toml_value<toml::Table>(data, "files", "<root>");
+    const auto& files = get_toml_value<toml::table>(data, "files", "<root>");
     const auto  path  = get_toml_value<std::string>(files, "output_path", "[files]");
 
     // XXX:  Here, this code assumes POSIX. it does not support windows.
@@ -142,7 +142,7 @@ read_input_file(const std::string& filename)
     MJOLNIR_GET_DEFAULT_LOGGER();
 
     MJOLNIR_LOG_NOTICE("the log file is `", logger_name, '`');
-    MJOLNIR_SCOPE(read_input_file(const toml::Table& data), 0);
+    MJOLNIR_SCOPE(read_input_file(const toml::table& data), 0);
 
     return read_precision(data); // read all the settings recursively...
 }

--- a/mjolnir/input/read_integrator.hpp
+++ b/mjolnir/input/read_integrator.hpp
@@ -1,6 +1,6 @@
 #ifndef MJOLNIR_READ_INTEGRATOR
 #define MJOLNIR_READ_INTEGRATOR
-#include <extlib/toml/toml.hpp>
+#include <extlib/toml/toml/toml.hpp>
 #include <mjolnir/core/VelocityVerletStepper.hpp>
 #include <mjolnir/core/UnderdampedLangevinStepper.hpp>
 #include <mjolnir/util/get_toml_value.hpp>
@@ -11,7 +11,7 @@ namespace mjolnir
 
 template<typename traitsT>
 VelocityVerletStepper<traitsT>
-read_velocity_verlet_stepper(const toml::Table& simulator)
+read_velocity_verlet_stepper(const toml::table& simulator)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_velocity_verlet_stepper(), 0);
@@ -27,21 +27,21 @@ read_velocity_verlet_stepper(const toml::Table& simulator)
 
 template<typename traitsT>
 UnderdampedLangevinStepper<traitsT>
-read_underdamped_langevin_stepper(const toml::Table& simulator)
+read_underdamped_langevin_stepper(const toml::table& simulator)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_underdamped_langevin_stepper(), 0);
     typedef typename traitsT::real_type real_type;
 
     const auto& parameters = // array of tables
-        get_toml_value<toml::Array>(simulator, "parameters", "[simulator]");
+        get_toml_value<toml::array>(simulator, "parameters", "[simulator]");
     const auto  seed =
         get_toml_value<std::uint32_t>(simulator, "seed", "[simulator]");
 
     std::vector<real_type> gamma(parameters.size());
     for(const auto& tab : parameters)
     {
-        const auto& params = tab.cast<toml::value_t::Table>();
+        const auto& params = toml::get<toml::table>(tab);
         const std::size_t idx = get_toml_value<std::size_t>(
                 params, "index", "<anonymous> in register");
         const real_type    gm = get_toml_value<real_type>(

--- a/mjolnir/input/read_interaction.hpp
+++ b/mjolnir/input/read_interaction.hpp
@@ -1,6 +1,6 @@
 #ifndef MJOLNIR_READ_INTERACTION
 #define MJOLNIR_READ_INTERACTION
-#include <extlib/toml/toml.hpp>
+#include <extlib/toml/toml/toml.hpp>
 #include <mjolnir/interaction/BondLengthInteraction.hpp>
 #include <mjolnir/interaction/BondAngleInteraction.hpp>
 #include <mjolnir/interaction/DihedralAngleInteraction.hpp>
@@ -27,7 +27,7 @@ namespace mjolnir
 
 template<typename traitsT>
 std::unique_ptr<LocalInteractionBase<traitsT>>
-read_bond_length_interaction(const std::string& kind, const toml::Table& local)
+read_bond_length_interaction(const std::string& kind, const toml::table& local)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_bond_length_interaction(), 0);
@@ -71,7 +71,7 @@ template<typename traitsT>
 std::unique_ptr<LocalInteractionBase<traitsT>>
 read_bond_angle_interaction(
     const typename LocalInteractionBase<traitsT>::connection_kind_type kind,
-    const toml::Table& local)
+    const toml::table& local)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_bond_angle_interaction(), 0);
@@ -115,7 +115,7 @@ template<typename traitsT>
 std::unique_ptr<LocalInteractionBase<traitsT>>
 read_dihedral_angle_interaction(
     const typename LocalInteractionBase<traitsT>::connection_kind_type kind,
-    const toml::Table& local)
+    const toml::table& local)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_dihedral_angle_interaction(), 0);
@@ -183,7 +183,7 @@ read_dihedral_angle_interaction(
 
 template<typename traitsT>
 std::unique_ptr<GlobalInteractionBase<traitsT>>
-read_global_pair_interaction(const toml::Table& global)
+read_global_pair_interaction(const toml::table& global)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_global_pair_interaction(), 0);
@@ -237,7 +237,7 @@ read_global_pair_interaction(const toml::Table& global)
 
 template<typename traitsT, typename shapeT>
 std::unique_ptr<ExternalForceInteractionBase<traitsT>>
-read_external_distance_interaction(const toml::Table& external, shapeT&& shape)
+read_external_distance_interaction(const toml::table& external, shapeT&& shape)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_global_distance_interaction(), 0);
@@ -283,13 +283,13 @@ read_external_distance_interaction(const toml::Table& external, shapeT&& shape)
 
 template<typename traitsT>
 std::unique_ptr<ExternalForceInteractionBase<traitsT>>
-read_external_distance_interaction_shape(const toml::Table& external)
+read_external_distance_interaction_shape(const toml::table& external)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_global_distance_interaction(), 0);
     using real_type = typename traitsT::real_type;
 
-    const auto shape = get_toml_value<toml::Table>(external, "shape",
+    const auto shape = get_toml_value<toml::table>(external, "shape",
             "[forcefield.external] for ExternalDistance");
     const auto name  = get_toml_value<std::string>(shape, "name",
             "[forcefield.external.shape] for ExternalDistance");
@@ -365,7 +365,7 @@ read_external_distance_interaction_shape(const toml::Table& external)
 
 template<typename traitsT>
 std::unique_ptr<LocalInteractionBase<traitsT>>
-read_local_interaction(const toml::Table& local)
+read_local_interaction(const toml::table& local)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_local_interaction(), 0);
@@ -400,7 +400,7 @@ read_local_interaction(const toml::Table& local)
 
 template<typename traitsT>
 std::unique_ptr<GlobalInteractionBase<traitsT>>
-read_global_interaction(const toml::Table& global)
+read_global_interaction(const toml::table& global)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_global_interaction(), 0);
@@ -421,7 +421,7 @@ read_global_interaction(const toml::Table& global)
 
 template<typename traitsT>
 std::unique_ptr<ExternalForceInteractionBase<traitsT>>
-read_external_interaction(const toml::Table& external)
+read_external_interaction(const toml::table& external)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_external_interaction(), 0);

--- a/mjolnir/input/read_observer.hpp
+++ b/mjolnir/input/read_observer.hpp
@@ -1,6 +1,6 @@
 #ifndef MJOLNIR_READ_OBSERVER
 #define MJOLNIR_READ_OBSERVER
-#include <extlib/toml/toml.hpp>
+#include <extlib/toml/toml/toml.hpp>
 #include <mjolnir/core/Observer.hpp>
 #include <mjolnir/util/get_toml_value.hpp>
 #include <mjolnir/util/logger.hpp>
@@ -10,13 +10,13 @@ namespace mjolnir
 
 template<typename traitsT>
 Observer<traitsT>
-read_observer(const toml::Table& data)
+read_observer(const toml::table& data)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_observer(), 0);
 
     const auto& files =
-        get_toml_value<toml::Table>(data, "files", "<root>");
+        get_toml_value<toml::table>(data, "files", "<root>");
 
     std::string path_ =
         get_toml_value<std::string>(files, "output_path", "[files]");

--- a/mjolnir/input/read_potential.hpp
+++ b/mjolnir/input/read_potential.hpp
@@ -1,6 +1,6 @@
 #ifndef MJOLNIR_READ_POTENTIAL
 #define MJOLNIR_READ_POTENTIAL
-#include <extlib/toml/toml.hpp>
+#include <extlib/toml/toml/toml.hpp>
 #include <mjolnir/potential/local/HarmonicPotential.hpp>
 #include <mjolnir/potential/local/Go1012ContactPotential.hpp>
 #include <mjolnir/potential/local/ClementiDihedralPotential.hpp>
@@ -30,7 +30,7 @@ namespace mjolnir
 // {indices = [1, 2], k = 10.0, v0 = 1.0} <- a portion of this table, k and v0.
 // ]
 template<typename realT>
-HarmonicPotential<realT> read_harmonic_potential(const toml::Table& param)
+HarmonicPotential<realT> read_harmonic_potential(const toml::table& param)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
@@ -45,7 +45,7 @@ HarmonicPotential<realT> read_harmonic_potential(const toml::Table& param)
 
 template<typename realT>
 Go1012ContactPotential<realT>
-read_go1012_contact_potential(const toml::Table& param)
+read_go1012_contact_potential(const toml::table& param)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
@@ -59,7 +59,7 @@ read_go1012_contact_potential(const toml::Table& param)
 }
 
 template<typename realT>
-GaussianPotential<realT> read_gaussian_potential(const toml::Table& param)
+GaussianPotential<realT> read_gaussian_potential(const toml::table& param)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
@@ -77,7 +77,7 @@ GaussianPotential<realT> read_gaussian_potential(const toml::Table& param)
 
 template<typename realT>
 AngularGaussianPotential<realT>
-read_angular_gaussian_potential(const toml::Table& param)
+read_angular_gaussian_potential(const toml::table& param)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
@@ -96,7 +96,7 @@ read_angular_gaussian_potential(const toml::Table& param)
 
 template<typename realT>
 FlexibleLocalAnglePotential<realT>
-read_flexible_local_angle_potential(const toml::Table& param)
+read_flexible_local_angle_potential(const toml::table& param)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
@@ -115,7 +115,7 @@ read_flexible_local_angle_potential(const toml::Table& param)
 
 template<typename realT>
 ClementiDihedralPotential<realT>
-read_clementi_dihedral_potential(const toml::Table& param)
+read_clementi_dihedral_potential(const toml::table& param)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
@@ -133,7 +133,7 @@ read_clementi_dihedral_potential(const toml::Table& param)
 
 template<typename realT>
 FlexibleLocalDihedralPotential<realT>
-read_flexible_local_dihedral_potential(const toml::Table& param)
+read_flexible_local_dihedral_potential(const toml::table& param)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
@@ -164,7 +164,7 @@ template<typename potentialT> struct read_local_potential_impl;
 template<typename realT>
 struct read_local_potential_impl<HarmonicPotential<realT>>
 {
-    static HarmonicPotential<realT> invoke(const toml::Table& param)
+    static HarmonicPotential<realT> invoke(const toml::table& param)
     {
         return read_harmonic_potential<realT>(param);
     }
@@ -172,7 +172,7 @@ struct read_local_potential_impl<HarmonicPotential<realT>>
 template<typename realT>
 struct read_local_potential_impl<Go1012ContactPotential<realT>>
 {
-    static Go1012ContactPotential<realT> invoke(const toml::Table& param)
+    static Go1012ContactPotential<realT> invoke(const toml::table& param)
     {
         return read_go1012_contact_potential<realT>(param);
     }
@@ -180,7 +180,7 @@ struct read_local_potential_impl<Go1012ContactPotential<realT>>
 template<typename realT>
 struct read_local_potential_impl<GaussianPotential<realT>>
 {
-    static GaussianPotential<realT> invoke(const toml::Table& param)
+    static GaussianPotential<realT> invoke(const toml::table& param)
     {
         return read_gaussian_potential<realT>(param);
     }
@@ -188,7 +188,7 @@ struct read_local_potential_impl<GaussianPotential<realT>>
 template<typename realT>
 struct read_local_potential_impl<AngularGaussianPotential<realT>>
 {
-    static AngularGaussianPotential<realT> invoke(const toml::Table& param)
+    static AngularGaussianPotential<realT> invoke(const toml::table& param)
     {
         return read_angular_gaussian_potential<realT>(param);
     }
@@ -196,7 +196,7 @@ struct read_local_potential_impl<AngularGaussianPotential<realT>>
 template<typename realT>
 struct read_local_potential_impl<FlexibleLocalAnglePotential<realT>>
 {
-    static FlexibleLocalAnglePotential<realT> invoke(const toml::Table& param)
+    static FlexibleLocalAnglePotential<realT> invoke(const toml::table& param)
     {
         return read_flexible_local_angle_potential<realT>(param);
     }
@@ -204,7 +204,7 @@ struct read_local_potential_impl<FlexibleLocalAnglePotential<realT>>
 template<typename realT>
 struct read_local_potential_impl<ClementiDihedralPotential<realT>>
 {
-    static ClementiDihedralPotential<realT> invoke(const toml::Table& param)
+    static ClementiDihedralPotential<realT> invoke(const toml::table& param)
     {
         return read_clementi_dihedral_potential<realT>(param);
     }
@@ -212,7 +212,7 @@ struct read_local_potential_impl<ClementiDihedralPotential<realT>>
 template<typename realT>
 struct read_local_potential_impl<FlexibleLocalDihedralPotential<realT>>
 {
-    static FlexibleLocalDihedralPotential<realT> invoke(const toml::Table& param)
+    static FlexibleLocalDihedralPotential<realT> invoke(const toml::table& param)
     {
         return read_flexible_local_dihedral_potential<realT>(param);
     }
@@ -223,7 +223,7 @@ struct read_local_potential_impl<FlexibleLocalDihedralPotential<realT>>
 // and returns pairs of [indices, potential parameters].
 template<std::size_t N, typename potentialT>
 std::vector<std::pair<std::array<std::size_t, N>, potentialT>>
-read_local_potential(const toml::Table& local)
+read_local_potential(const toml::table& local)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_local_potential(), 0);
@@ -232,7 +232,7 @@ read_local_potential(const toml::Table& local)
     using indices_t                = std::array<std::size_t, N>;
     using indices_potential_pair_t = std::pair<indices_t, potentialT>;
 
-    const auto& params = get_toml_value<toml::Array>(
+    const auto& params = get_toml_value<toml::array>(
             local, "parameters", "[[forcefield.local]]");
     MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
 
@@ -240,7 +240,7 @@ read_local_potential(const toml::Table& local)
     retval.reserve(params.size());
     for(const auto& item : params)
     {
-        const auto& parameter = item.cast<toml::value_t::Table>();
+        const auto& parameter = toml::get<toml::table>(item);
 
         const auto indices = get_toml_value<indices_t>(parameter, "indices",
                 "element of [[forcefields.local.parameters]]");
@@ -256,7 +256,7 @@ template<std::size_t N, typename realT,
          typename potentialT1, typename potentialT2>
 std::vector<std::pair<std::array<std::size_t, N>,
             SumLocalPotential<realT, potentialT1, potentialT2>>>
-read_local_potentials(const toml::Table& local,
+read_local_potentials(const toml::table& local,
                       const std::string& p1, const std::string& p2)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
@@ -267,7 +267,7 @@ read_local_potentials(const toml::Table& local,
     using indices_potential_pair_t = std::pair<indices_t,
         SumLocalPotential<realT, potentialT1, potentialT2>>;
 
-    const auto& params = get_toml_value<toml::Array>(
+    const auto& params = get_toml_value<toml::array>(
             local, "parameters", "[[forcefield.local]]");
     MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
 
@@ -275,16 +275,16 @@ read_local_potentials(const toml::Table& local,
     retval.reserve(params.size());
     for(const auto& item : params)
     {
-        const auto& parameter = item.cast<toml::value_t::Table>();
+        const auto& parameter = toml::get<toml::table>(item);
 
         const auto indices = get_toml_value<indices_t>(parameter, "indices",
                 "element of [[forcefields.local.parameters]]");
         MJOLNIR_LOG_INFO("idxs = ", indices);
 
         const auto& pot1 =
-            get_toml_value<toml::Table>(parameter, p1, "[[forcefield.local]]");
+            get_toml_value<toml::table>(parameter, p1, "[[forcefield.local]]");
         const auto& pot2 =
-            get_toml_value<toml::Table>(parameter, p2, "[[forcefield.local]]");
+            get_toml_value<toml::table>(parameter, p2, "[[forcefield.local]]");
 
         retval.emplace_back(indices,
             SumLocalPotential<realT, potentialT1, potentialT2>(
@@ -330,7 +330,7 @@ read_ignored_molecule(const std::string& ignored_mol)
 
 template<typename realT>
 ExcludedVolumePotential<realT>
-read_excluded_volume_potential(const toml::Table& global)
+read_excluded_volume_potential(const toml::table& global)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_excluded_volume_potential(), 0);
@@ -339,14 +339,14 @@ read_excluded_volume_potential(const toml::Table& global)
     const auto location = "[forcefield.global] for ExcludedVolume potential";
 
     const auto& ignore =
-        get_toml_value<toml::Table>(global, "ignore", location);
+        get_toml_value<toml::table>(global, "ignore", location);
 
     auto ignored_mol = read_ignored_molecule(
         get_toml_value<std::string>(ignore, "molecule", location));
 
     std::map<std::string, std::size_t> connections;
     for(const auto connection :
-            get_toml_value<toml::Table>(ignore, "particles_within", location))
+            get_toml_value<toml::table>(ignore, "particles_within", location))
     {
         connections[connection.first] =
             toml::get<std::size_t>(connection.second);
@@ -359,7 +359,7 @@ read_excluded_volume_potential(const toml::Table& global)
         global, "epsilon", location);
     MJOLNIR_LOG_INFO("epsilon = ", eps);
 
-    const auto& ps = get_toml_value<toml::Array>(global, "parameters", location);
+    const auto& ps = get_toml_value<toml::array>(global, "parameters", location);
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
     const auto parameters =
         "element of [[forcefield.global.parameters]] for ExcludedVolume";
@@ -369,7 +369,7 @@ read_excluded_volume_potential(const toml::Table& global)
 
     for(const auto& param : ps)
     {
-        const auto& tab = param.cast<toml::value_t::Table>();
+        const auto& tab = toml::get<toml::table>(param);
         const auto  idx = get_toml_value<std::size_t>(tab, "index", parameters);
         if(params.size() <= idx)
         {
@@ -387,7 +387,7 @@ read_excluded_volume_potential(const toml::Table& global)
 
 template<typename realT>
 LennardJonesPotential<realT>
-read_lennard_jones_potential(const toml::Table& global)
+read_lennard_jones_potential(const toml::table& global)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_lennard_jones_potential(), 0);
@@ -396,14 +396,14 @@ read_lennard_jones_potential(const toml::Table& global)
     const auto location   = "[forcefield.global] for LennardJones potential";
 
     const auto& ignore =
-        get_toml_value<toml::Table>(global, "ignore", location);
+        get_toml_value<toml::table>(global, "ignore", location);
 
     auto ignored_mol = read_ignored_molecule(
         get_toml_value<std::string>(ignore, "molecule", location));
 
     std::map<std::string, std::size_t> connections;
     for(const auto connection :
-        get_toml_value<toml::Table>(ignore, "particles_within", location))
+        get_toml_value<toml::table>(ignore, "particles_within", location))
     {
         connections[connection.first] =
             toml::get<std::size_t>(connection.second);
@@ -412,7 +412,7 @@ read_lennard_jones_potential(const toml::Table& global)
                          "be ignored");
     }
 
-    const auto& ps = get_toml_value<toml::Array>(global, "parameters", location);
+    const auto& ps = get_toml_value<toml::array>(global, "parameters", location);
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
     const auto parameters =
         "element of [[forcefield.global.parameters]] for Lennard-Jones";
@@ -421,7 +421,7 @@ read_lennard_jones_potential(const toml::Table& global)
     params.reserve(ps.size());
     for(const auto& param : ps)
     {
-        const auto& tab = param.cast<toml::value_t::Table>();
+        const auto& tab = toml::get<toml::table>(param);
         const auto idx = get_toml_value<std::size_t>(tab, "index", parameters);
         if(params.size() <= idx)
         {
@@ -441,7 +441,7 @@ read_lennard_jones_potential(const toml::Table& global)
 
 template<typename realT>
 UniformLennardJonesPotential<realT>
-read_uniform_lennard_jones_potential(const toml::Table& global)
+read_uniform_lennard_jones_potential(const toml::table& global)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_uniform_lennard_jones_potential(), 0);
@@ -449,14 +449,14 @@ read_uniform_lennard_jones_potential(const toml::Table& global)
     const auto location = "[forcefield.global] for UniformLennardJones";
 
     const auto& ignore =
-        get_toml_value<toml::Table>(global, "ignore", location);
+        get_toml_value<toml::table>(global, "ignore", location);
 
     auto ignored_mol = read_ignored_molecule(
         get_toml_value<std::string>(ignore, "molecule", location));
 
     std::map<std::string, std::size_t> connections;
     for(const auto connection :
-            get_toml_value<toml::Table>(ignore, "particles_within", location))
+            get_toml_value<toml::table>(ignore, "particles_within", location))
     {
         connections[connection.first] =
             toml::get<std::size_t>(connection.second);
@@ -477,7 +477,7 @@ read_uniform_lennard_jones_potential(const toml::Table& global)
 
 template<typename realT>
 DebyeHuckelPotential<realT>
-read_debye_huckel_potential(const toml::Table& global)
+read_debye_huckel_potential(const toml::table& global)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_debye_huckel_potential(), 0);
@@ -485,14 +485,14 @@ read_debye_huckel_potential(const toml::Table& global)
     const auto location = "[forcefield.global] for DebyeHuckel";
 
     const auto& ignore =
-        get_toml_value<toml::Table>(global, "ignore", location);
+        get_toml_value<toml::table>(global, "ignore", location);
 
     auto ignored_mol = read_ignored_molecule(
         get_toml_value<std::string>(ignore, "molecule", location));
 
     std::map<std::string, std::size_t> connections;
     for(const auto connection :
-            get_toml_value<toml::Table>(ignore, "particles_within", location))
+            get_toml_value<toml::table>(ignore, "particles_within", location))
     {
         connections[connection.first] =
             toml::get<std::size_t>(connection.second);
@@ -501,7 +501,7 @@ read_debye_huckel_potential(const toml::Table& global)
                          "be ignored");
     }
 
-    const auto& ps = get_toml_value<toml::Array>(global, "parameters", location);
+    const auto& ps = get_toml_value<toml::array>(global, "parameters", location);
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
 
     const auto parameters =
@@ -511,7 +511,7 @@ read_debye_huckel_potential(const toml::Table& global)
     params.reserve(ps.size());
     for(const auto& param : ps)
     {
-        const auto& tab = param.cast<toml::value_t::Table>();
+        const auto& tab = toml::get<toml::table>(param);
         const auto idx = get_toml_value<std::size_t>(tab, "index", parameters);
         const auto charge = get_toml_value<real_type>(tab, "charge", parameters);
         MJOLNIR_LOG_INFO("idx    = ", idx, ", charge = ", charge);
@@ -532,7 +532,7 @@ read_debye_huckel_potential(const toml::Table& global)
 
 template<typename realT>
 ImplicitMembranePotential<realT>
-read_implicit_membrane_potential(const toml::Table& external)
+read_implicit_membrane_potential(const toml::table& external)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_implicit_membrane_potential(), 0);
@@ -548,7 +548,7 @@ read_implicit_membrane_potential(const toml::Table& external)
     MJOLNIR_LOG_INFO("magnitude = ", magnitude);
     MJOLNIR_LOG_INFO("bend      = ", bend     );
 
-    const auto& ps = get_toml_value<toml::Array>(external, "parameters",
+    const auto& ps = get_toml_value<toml::array>(external, "parameters",
             location);
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
 
@@ -559,7 +559,7 @@ read_implicit_membrane_potential(const toml::Table& external)
     params.reserve(ps.size());
     for(const auto& param : ps)
     {
-        const auto& tab = param.cast<toml::value_t::Table>();
+        const auto& tab = toml::get<toml::table>(param);
         const auto idx = get_toml_value<std::size_t>(tab, "index", parameters);
         const auto h   = get_toml_value<real_type>(tab, "hydrophobicity",
                                                    parameters);
@@ -578,14 +578,14 @@ read_implicit_membrane_potential(const toml::Table& external)
 
 template<typename realT>
 LennardJonesWallPotential<realT>
-read_lennard_jones_wall_potential(const toml::Table& external)
+read_lennard_jones_wall_potential(const toml::table& external)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_lennard_jones_wall_potential(), 0);
     using real_type = realT;
     const auto location = "[forcefield.external] for Lennard-Jones Wall";
 
-    const auto& ps = get_toml_value<toml::Array>(external, "parameters", location);
+    const auto& ps = get_toml_value<toml::array>(external, "parameters", location);
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
 
     const auto parameters =
@@ -595,7 +595,7 @@ read_lennard_jones_wall_potential(const toml::Table& external)
     params.reserve(ps.size());
     for(const auto& param : ps)
     {
-        const auto& tab = param.cast<toml::value_t::Table>();
+        const auto& tab = toml::get<toml::table>(param);
         const auto idx = get_toml_value<std::size_t>(tab, "index", parameters);
         const auto s = get_toml_value<real_type>(tab, {"sigma"_s,   u8"σ"_s}, parameters);
         const auto e = get_toml_value<real_type>(tab, {"epsilon"_s, u8"ε"_s}, parameters);
@@ -612,7 +612,7 @@ read_lennard_jones_wall_potential(const toml::Table& external)
 
 template<typename realT>
 ExcludedVolumeWallPotential<realT>
-read_excluded_volume_wall_potential(const toml::Table& external)
+read_excluded_volume_wall_potential(const toml::table& external)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_excluded_volume_wall_potential(), 0);
@@ -622,7 +622,7 @@ read_excluded_volume_wall_potential(const toml::Table& external)
     const real_type eps = get_toml_value<real_type>(external, "epsilon", location);
     MJOLNIR_LOG_INFO("epsilon = ", eps);
 
-    const auto& ps = get_toml_value<toml::Array>(external, "parameters", location);
+    const auto& ps = get_toml_value<toml::array>(external, "parameters", location);
     MJOLNIR_LOG_INFO("number of parameters = ", ps.size());
 
     const auto parameters =
@@ -632,7 +632,7 @@ read_excluded_volume_wall_potential(const toml::Table& external)
     params.reserve(ps.size());
     for(const auto& param : ps)
     {
-        const auto& tab = param.cast<toml::value_t::Table>();
+        const auto& tab = toml::get<toml::table>(param);
         const auto idx = get_toml_value<std::size_t>(tab, "index", parameters);
         const auto s = get_toml_value<real_type>(tab, {"sigma"_s, u8"σ"_s}, parameters);
         MJOLNIR_LOG_INFO("idx = ", idx, ", sigma = ", s);

--- a/mjolnir/input/read_simulator.hpp
+++ b/mjolnir/input/read_simulator.hpp
@@ -1,6 +1,6 @@
 #ifndef MJOLNIR_READ_SIMULATOR
 #define MJOLNIR_READ_SIMULATOR
-#include <extlib/toml/toml.hpp>
+#include <extlib/toml/toml/toml.hpp>
 #include <mjolnir/core/MolecularDynamicsSimulator.hpp>
 #include <mjolnir/core/SteepestDescentSimulator.hpp>
 #include <mjolnir/core/SimulatedAnnealingSimulator.hpp>
@@ -19,7 +19,7 @@ namespace mjolnir
 template<typename traitsT>
 std::unique_ptr<SimulatorBase>
 read_molecular_dynamics_simulator(
-        const toml::Table& data, const toml::Table& simulator)
+        const toml::table& data, const toml::table& simulator)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_molecular_dynamics_simulator(), 0);
@@ -68,7 +68,7 @@ read_molecular_dynamics_simulator(
 template<typename traitsT>
 std::unique_ptr<SimulatorBase>
 read_steepest_descent_simulator(
-        const toml::Table& data, const toml::Table& simulator)
+        const toml::table& data, const toml::table& simulator)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_steepest_descent_simulator(), 0);
@@ -99,7 +99,7 @@ read_steepest_descent_simulator(
 template<typename traitsT>
 std::unique_ptr<SimulatorBase>
 read_simulated_annealing_simulator(
-        const toml::Table& data, const toml::Table& simulator)
+        const toml::table& data, const toml::table& simulator)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_simulated_annealing_simulator(), 0);
@@ -168,7 +168,7 @@ read_simulated_annealing_simulator(
 
 template<typename traitsT>
 std::unique_ptr<SimulatorBase>
-read_simulator_from_table(const toml::Table& data, const toml::Table& simulator)
+read_simulator_from_table(const toml::table& data, const toml::table& simulator)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_simulator_from_table(), 0);
@@ -199,16 +199,16 @@ read_simulator_from_table(const toml::Table& data, const toml::Table& simulator)
 
 template<typename traitsT>
 std::unique_ptr<SimulatorBase>
-read_simulator(const toml::Table& data)
+read_simulator(const toml::table& data)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_simulator(), 0);
 
     using real_type   = typename traitsT::real_type;
     const auto& simulator =
-        get_toml_value<toml::Table>(data, "simulator", "<root>");
+        get_toml_value<toml::table>(data, "simulator", "<root>");
 
-    const auto& files = get_toml_value<toml::Table>(data, "files", "<root>");
+    const auto& files = get_toml_value<toml::table>(data, "files", "<root>");
     std::string input_path_("./");
     if(files.count("input_path") == 1)
     {
@@ -242,18 +242,18 @@ read_simulator(const toml::Table& data)
             MJOLNIR_LOG_WARN("but in ", file_name, ", `simulator` key found. "
                              "trying to read it as a simulator setup.");
 
-            if(simulator_file.at("simulator").type() != toml::value_t::Table)
+            if(!simulator_file.at("simulator").is(toml::value::table_tag))
             {
                 MJOLNIR_LOG_ERROR("type of `simulator` is different from "
-                                  "toml::Table in file (", file_name, ").");
+                                  "toml::table in file (", file_name, ").");
                 MJOLNIR_LOG_ERROR("note: [[...]] means Array-of-Tables. "
                                   "please take care.");
                 std::exit(1);
             }
 
             MJOLNIR_LOG_INFO("reading `[simulator]` table");
-            return read_simulator_from_table<traitsT>(data, simulator_file.at(
-                    "simulator").template cast<toml::value_t::Table>());
+            return read_simulator_from_table<traitsT>(data,
+                    toml::get<toml::table>(simulator_file.at("simulator")));
         }
         return read_simulator_from_table<traitsT>(data, simulator_file);
     }

--- a/mjolnir/input/read_spatial_partition.hpp
+++ b/mjolnir/input/read_spatial_partition.hpp
@@ -42,14 +42,14 @@ struct celllist_dispatcher<CuboidalPeriodicBoundary<realT, coordT>, traitsT, par
 
 template<typename traitsT, typename potentialT>
 std::unique_ptr<GlobalInteractionBase<traitsT>>
-read_spatial_partition(const toml::Table& global, potentialT&& pot)
+read_spatial_partition(const toml::table& global, potentialT&& pot)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_SCOPE(read_spatial_partition(), 0);
     typedef typename traitsT::real_type         real_type;
     typedef typename potentialT::parameter_type parameter_type;
 
-    const auto& sp   = get_toml_value<toml::Table>(
+    const auto& sp   = get_toml_value<toml::table>(
             global, "spatial_partition", "[forcefield.global]");
     const auto  type = get_toml_value<std::string>(
             sp, "type", "[forcefield.global]");

--- a/mjolnir/input/read_units.hpp
+++ b/mjolnir/input/read_units.hpp
@@ -1,6 +1,6 @@
 #ifndef MJOLNIR_READ_UNIT_SYSTEM_HPP
 #define MJOLNIR_READ_UNIT_SYSTEM_HPP
-#include <extlib/toml/toml.hpp>
+#include <extlib/toml/toml/toml.hpp>
 #include <mjolnir/math/constants.hpp>
 #include <mjolnir/core/constants.hpp>
 #include <mjolnir/core/Unit.hpp>
@@ -13,16 +13,16 @@ namespace mjolnir
 {
 
 template<typename traitsT>
-std::unique_ptr<SimulatorBase> read_units(const toml::Table& data)
+std::unique_ptr<SimulatorBase> read_units(const toml::table& data)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
-    MJOLNIR_SCOPE(read_units(const toml::Table& data), 0);
+    MJOLNIR_SCOPE(read_units(const toml::table& data), 0);
     using real_type = typename traitsT::real_type;
     using phys_type = physics::constants<real_type>;
     using math_type = math::constants<real_type>;
     using unit_type = unit::constants<real_type>;
 
-    const auto& units = get_toml_value<toml::Table>(data, "units", "<root>");
+    const auto& units = get_toml_value<toml::table>(data, "units", "<root>");
 
     const auto& energy = get_toml_value<std::string>(units, "energy", "[units]");
     const auto& length = get_toml_value<std::string>(units, "length", "[units]");

--- a/test/mjolnir/test_unit.cpp
+++ b/test/mjolnir/test_unit.cpp
@@ -1,4 +1,5 @@
 #define BOOST_TEST_MODULE "test_unit_conversion"
+#include <extlib/toml/toml/toml.hpp>
 #include <boost/test/included/unit_test.hpp>
 #include <boost/mpl/list.hpp>
 #include <test/util/make_empty_input.hpp>
@@ -57,7 +58,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(read_input_angstrom_kcalmol, Real, test_targets)
     using unit = mjolnir::unit::constants<Real>;
 
     auto input = mjolnir::test::make_empty_input();
-    auto& units = input["units"].cast<toml::value_t::Table>();
+    auto& units = toml::get<toml::table>(input["units"]);
 
     units["length"] = "angstrom"_s;
     units["energy"] = "kcal/mol"_s;
@@ -96,7 +97,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(read_input_angstrom_kJmol, Real, test_targets)
 
 
     auto input  = mjolnir::test::make_empty_input();
-    auto& units = input["units"].cast<toml::value_t::Table>();
+    auto& units = toml::get<toml::table>(input["units"]);
 
     units["length"] = "angstrom"_s;
     units["energy"] = "kJ/mol"_s;
@@ -134,7 +135,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(read_input_nm_kcalmol, Real, test_targets)
     using unit = mjolnir::unit::constants<Real>;
 
     auto input = mjolnir::test::make_empty_input();
-    auto& units = input["units"].cast<toml::value_t::Table>();
+    auto& units = toml::get<toml::table>(input["units"]);
 
     units["length"] = "nm"_s;
     units["energy"] = "kcal/mol"_s;
@@ -172,7 +173,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(read_input_nm_kJmol, Real, test_targets)
     using unit = mjolnir::unit::constants<Real>;
 
     auto input  = mjolnir::test::make_empty_input();
-    auto& units = input["units"].cast<toml::value_t::Table>();
+    auto& units = toml::get<toml::table>(input["units"]);
 
     units["length"] = "nm"_s;
     units["energy"] = "kJ/mol"_s;

--- a/test/util/make_empty_input.hpp
+++ b/test/util/make_empty_input.hpp
@@ -1,6 +1,6 @@
 #ifndef MJOLNIR_TEST_MAKE_EMPTY_INPUT_HPP
 #define MJOLNIR_TEST_MAKE_EMPTY_INPUT_HPP
-#include <extlib/toml/toml.hpp>
+#include <extlib/toml/toml/toml.hpp>
 #include <mjolnir/util/string.hpp>
 
 namespace mjolnir
@@ -10,22 +10,22 @@ namespace test
 
 // make a minimal input file that contains no particle, no forcefield.
 // It contains only parameters that are needed to pass read_input() functions.
-inline toml::Table make_empty_input()
+inline toml::table make_empty_input()
 {
     using namespace mjolnir::literals::string_literals;
 
-    toml::Table files;
+    toml::table files;
     files["output_prefix"] = "nothing"_s;
     files["output_path"]   = "./"_s;
 
-    toml::Table units;
+    toml::table units;
     units["length"] = "angstrom"_s;
     units["energy"] = "kcal/mol"_s;
 
     // Mjolnir does not consider running simulation without simulator
     // (that does not make sense!) . Here, temporary set MD simulator with
     // Newtonian dynamics.
-    toml::Table simulator;
+    toml::table simulator;
     simulator["type"]          = "Molecular Dynamics"_s;
     simulator["scheme"]        = "Newtonian"_s;
     simulator["precision"]     = "double"_s;
@@ -35,18 +35,18 @@ inline toml::Table make_empty_input()
     simulator["delta_t"]       = 0.1;
 
     // Mjolnir requires a system to simulate, even if it has no particle.
-    toml::Table system;
-    system["attributes"]     = toml::Table{{"temperature"_s, toml::value(300.0)}};
-    system["boundary_shape"] = toml::Table(); // no boundary
-    system["particles"]      = toml::Array(); // no particle
-    toml::Array systems(1, std::move(system));
+    toml::table system;
+    system["attributes"]     = toml::table{{"temperature"_s, toml::value(300.0)}};
+    system["boundary_shape"] = toml::table(); // no boundary
+    system["particles"]      = toml::array(); // no particle
+    toml::array systems(1, std::move(system));
 
     // "empty forcefields" completely make sense because essentially any kind of
     // forcefields are a sum of several potential terms. Forcefield that has
     // zero term means an ideal system having no interaction.
-    toml::Array forcefields(1, toml::Table(/* nothing! */));
+    toml::array forcefields(1, toml::table(/* nothing! */));
 
-    toml::Table input;
+    toml::table input;
     input["files"]       = std::move(files);
     input["units"]       = std::move(units);
     input["simulator"]   = std::move(simulator);


### PR DESCRIPTION
### pros
  - support TOML v0.5.0
  - shorter and simpler code in `read_*` functions
### cons
  - longer compilation time
    - approximately x1.25 slower
  - deeper dependency on Boost
    - currently, only the test codes depend on Boost...