### PR TITLE
Use the same name in every ForceFields

### DIFF
--- a/mjolnir/core/ExternalForceInteractionBase.hpp
+++ b/mjolnir/core/ExternalForceInteractionBase.hpp
@@ -1,6 +1,7 @@
 #ifndef MJOLNIR_EXTERNAL_FORCE_INTEARACTION_BASE
 #define MJOLNIR_EXTERNAL_FORCE_INTEARACTION_BASE
 #include <mjolnir/core/System.hpp>
+#include <string>
 
 namespace mjolnir
 {
@@ -20,8 +21,8 @@ class ExternalForceInteractionBase
 
     virtual ~ExternalForceInteractionBase() = default;
 
-    virtual void initialize (const system_type& sys) = 0;
-    virtual void reconstruct(const system_type& sys) = 0;
+    virtual void initialize(const system_type&) = 0;
+    virtual void update    (const system_type&) = 0;
 
     virtual void      calc_force (system_type&)             = 0;
     virtual real_type calc_energy(const system_type&) const = 0;

--- a/mjolnir/core/GlobalInteractionBase.hpp
+++ b/mjolnir/core/GlobalInteractionBase.hpp
@@ -1,6 +1,7 @@
 #ifndef MJOLNIR_GLOBAL_INTEARACTION_BASE
 #define MJOLNIR_GLOBAL_INTEARACTION_BASE
 #include <mjolnir/core/System.hpp>
+#include <string>
 
 namespace mjolnir
 {
@@ -20,8 +21,8 @@ class GlobalInteractionBase
 
     virtual ~GlobalInteractionBase() = default;
 
-    virtual void initialize(const system_type& sys) = 0;
-    virtual void update    (const system_type& sys) = 0;
+    virtual void initialize(const system_type&) = 0;
+    virtual void update    (const system_type&) = 0;
 
     virtual void      calc_force (system_type&)             = 0;
     virtual real_type calc_energy(const system_type&) const = 0;

--- a/mjolnir/core/LocalInteractionBase.hpp
+++ b/mjolnir/core/LocalInteractionBase.hpp
@@ -1,8 +1,7 @@
 #ifndef MJOLNIR_LOCAL_INTEARACTION_BASE
 #define MJOLNIR_LOCAL_INTEARACTION_BASE
 #include <mjolnir/core/System.hpp>
-#include <memory>
-#include <array>
+#include <string>
 
 namespace mjolnir
 {

--- a/mjolnir/interaction/ExternalDistanceInteraction.hpp
+++ b/mjolnir/interaction/ExternalDistanceInteraction.hpp
@@ -49,7 +49,7 @@ class ExternalDistanceInteraction final
      *  @details A method that change system parameters (e.g. Annealing), *
      *           the method is bound to call this function after changing *
      *           parameters.                                              */
-    void reconstruct(const system_type& sys) override
+    void update(const system_type& sys) override
     {
         this->potential_.update(sys); // update system parameters
         this->shape_.reconstruct(sys, this->potential_);


### PR DESCRIPTION
`ExternalForceField` uses `reconstruct`, but others use `update` to update parameter values.

Use the same name for the consistency.